### PR TITLE
add cascade option

### DIFF
--- a/db/migrate/20180905191156_delete_legacy_tables.rb
+++ b/db/migrate/20180905191156_delete_legacy_tables.rb
@@ -1,7 +1,7 @@
 class DeleteLegacyTables < ActiveRecord::Migration[5.1]
   def change
     drop_table :users
-    drop_table :configs
-    drop_table :config_groups
+    drop_table :configs, force: :cascade
+    drop_table :config_groups, force: :cascade
   end
 end


### PR DESCRIPTION
heroku上でdb migrateができないバグに関する修正を行いました。

今回の状況として、本日のデプロイで引き継ぎの際に行ったリファクタリングのコードが本番環境に適用されました。（その前本番環境に適用しておくべきでした。）
そのコードの中で不要なテーブルを削除する過程があり、テーブルの依存関係が原因でテーブル削除がうまくできていなかったためにエラーが発生していたので、その依存関係を無視するためのcascadeオプションを追加しました。