### PR TITLE
single search with Japanese

### DIFF
--- a/app/controllers/api/transcripts_controller.rb
+++ b/app/controllers/api/transcripts_controller.rb
@@ -53,10 +53,10 @@ class Api::TranscriptsController < ApplicationController
   end
 
   def create
-    default_nlp = 'MS'
+    default_nlp = 'GCP' # Next100対応
     is_word_only = true
     is_concurrent = true # trueにするとtranscript, search, related_contentを非同期的にDB登録します。alpha版以前の仕様でアプリを実行する場合にはfalseにしてください。
-    multiple_search = true
+    multiple_search = false # Next100対応
     is_test_mode = false
 
     # nlp switcher

--- a/lib/assets/nlp/nlp_gcp.rb
+++ b/lib/assets/nlp/nlp_gcp.rb
@@ -35,19 +35,21 @@ def analyze_text_gcp(text, langcode)
 
   for entity in entities
     ## extract only proper
-    if entity['mentions'][0]['type'] == 'PROPER'
-      entity_hash = {}
-      entity_hash.store('name', entity['name'])
-      entity_hash.store('category', entity['type'])
-      entities_hash.push(entity_hash)
-    else
-      puts('common entity')
-      puts(entity)
-    end
-    # entity_hash = {}
-    # entity_hash.store('name', entity['name'])
-    # entity_hash.store('category', entity['type'])
-    # entities_hash.push(entity_hash)
+    # if entity['mentions'][0]['type'] == 'PROPER'
+    #   entity_hash = {}
+    #   entity_hash.store('name', entity['name'])
+    #   entity_hash.store('category', entity['type'])
+    #   entities_hash.push(entity_hash)
+    # else
+    #   puts('common entity')
+    #   puts(entity)
+    # end
+
+    ## extract all noun
+    entity_hash = {}
+    entity_hash.store('name', entity['name'])
+    entity_hash.store('category', entity['type'])
+    entities_hash.push(entity_hash)
   end
   return entities_hash, sentiment
 end

--- a/lib/assets/search/search_handler.rb
+++ b/lib/assets/search/search_handler.rb
@@ -68,7 +68,7 @@ def image_search(word, search, transcript, langcode, is_concurrent)
   threads = []
   threads << Thread.new do
     ActiveRecord::Base.connection_pool.with_connection do
-      ms_image_search(word, search, transcript, langcode, is_concurrent, 5, contents)
+      ms_image_search(word, search, transcript, langcode, is_concurrent, 6, contents)
     end
   end
   ## Next 100対応でunsplash削除
@@ -84,7 +84,7 @@ def image_search(word, search, transcript, langcode, is_concurrent)
   # end
   threads << Thread.new do
     ActiveRecord::Base.connection_pool.with_connection do
-      flickr(word, search, transcript, langcode, is_concurrent, 4, contents)
+      flickr(word, search, transcript, langcode, is_concurrent, 3, contents)
     end
   end
   # google_custom_search(word, search, transcript, langcode, is_concurrent, 3, contents)

--- a/lib/assets/search/search_handler.rb
+++ b/lib/assets/search/search_handler.rb
@@ -71,11 +71,12 @@ def image_search(word, search, transcript, langcode, is_concurrent)
       ms_image_search(word, search, transcript, langcode, is_concurrent, 5, contents)
     end
   end
-  threads << Thread.new do
-    ActiveRecord::Base.connection_pool.with_connection do
-      unsplash(word, search, transcript, langcode, is_concurrent, 2, contents)
-    end
-  end
+  ## Next 100対応でunsplash削除
+  # threads << Thread.new do
+  #   ActiveRecord::Base.connection_pool.with_connection do
+  #     unsplash(word, search, transcript, langcode, is_concurrent, 2, contents)
+  #   end
+  # end
   # threads << Thread.new do
   #   ActiveRecord::Base.connection_pool.with_connection do
   #     getty_images(word, search, transcript, langcode, is_concurrent, 2, contents)
@@ -83,7 +84,7 @@ def image_search(word, search, transcript, langcode, is_concurrent)
   # end
   threads << Thread.new do
     ActiveRecord::Base.connection_pool.with_connection do
-      flickr(word, search, transcript, langcode, is_concurrent, 2, contents)
+      flickr(word, search, transcript, langcode, is_concurrent, 4, contents)
     end
   end
   # google_custom_search(word, search, transcript, langcode, is_concurrent, 3, contents)

--- a/lib/assets/search/search_handler.rb
+++ b/lib/assets/search/search_handler.rb
@@ -46,11 +46,7 @@ end
 
 def production_alpha(word, search, transcript, langcode, is_concurrent, search_type)
   if search_type.zero?
-    contents = if transcript.wall_id == 3
-                 image_search_beta(word, search, transcript, langcode, is_concurrent)
-               else
-                 image_search(word, search, transcript, langcode, is_concurrent)
-               end
+    contents = image_search(word, search, transcript, langcode, is_concurrent)
   elsif search_type == 1
     contents = news_search(word, search, transcript, langcode, is_concurrent)
   elsif search_type == 2
@@ -90,19 +86,6 @@ def image_search(word, search, transcript, langcode, is_concurrent)
   # google_custom_search(word, search, transcript, langcode, is_concurrent, 3, contents)
   threads.each { |t| t.join } unless is_concurrent
   # threads.each { |t| t.join }
-
-  contents
-end
-
-def image_search_beta(word, search, transcript, langcode, is_concurrent)
-  contents = []
-  threads = []
-  threads << Thread.new do
-    ActiveRecord::Base.connection_pool.with_connection do
-      ms_image_search(word, search, transcript, langcode, is_concurrent, 5, contents)
-    end
-  end
-  threads.each { |t| t.join } unless is_concurrent
 
   contents
 end


### PR DESCRIPTION
以下の対応をおこないました。

1.　google翻訳をかまさなくていいように日本語をそのままクエリに使える画像検索APIに絞っています。画像の引用元に関してはMS bing searchの表示結果を6つ、Flickrの検索結果を3つ表示するように変更しました。

2. より多くの名詞を検索するために、Googleのエンティティ分析APIに変更して現在は普通名詞、固有名詞共に表示しています。今まではMicrosoftのキーワード検知APIを使用していました。
https://cloud.google.com/natural-language/docs/analyzing-entities?hl=ja

3. And検索をなくして今は各単語の検索に統一しました。

>1.画像の参照先は日本語で画像が豊富なところに切り替えたいです。ちなみに翻訳を通さないことで多少レスポンスの速度が上がることって期待できますか？
>2. NPLの結果で抽出された名詞は全て検索していきたいです。
>3. AND検索をなくすことってできますか？いま喋ってると「エヴァンゲリオン＋おはよう」のような検索になっていいて、正直なところ関連性がない検索だったり検索の結果がなかったりすることが多く・・・。