### PR TITLE
Contentsbug

### DIFF
--- a/lib/assets/api/transcripts/get_searches.rb
+++ b/lib/assets/api/transcripts/get_searches.rb
@@ -147,6 +147,7 @@ def get_all_searches(wall_id)
     search_last_index = 0
     search_first_index = 0
     related_content_last_index = 0
+    related_contents = []
   end
 
   return search_list, search_last_index, search_first_index, related_contents, related_content_last_index


### PR DESCRIPTION
related_contentsがまだ作成されていない状況で`/next100/contents?wall_id=:id`にリクエストを送るとjsonレスポンスのrelated_contentsにおいて空の配列(`[]`)を返すようにコードを修正しています。

>問題となっているページのソースコードがどれかわからずよく調査できていないのですが（申し訳ないです）、もしかして`/next100/contents?wall_id=:id`のレスポンスの差分を取得してページのコンテンツを更新している場合に、related_contentsがまだ作成されていない状態で`/next100/contents?wall_id=:id`にリクエストを送るとjsonレスポンスのrelated_contentsにnullが返ってしまっていたことがバグの原因となってしまっていたかもしれません。